### PR TITLE
Remove accidentally added duplicate requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,3 @@ chrono = "0.4.19"
 tokio = { version = "1", features = ["full"] }
 tower = "0.4.12"
 tower-http = "0.2.5"
-postgres-es = { path = "../postgres-es" }


### PR DESCRIPTION
Looks like a version bump accidentally left a dependency in the Cargo.toml. This commit removes that.